### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos10_vrrp.j2
+++ b/templates/dellos10_vrrp.j2
@@ -45,7 +45,7 @@ dellos_vrrp:
       vrrp_active_active_mode: True
 #########################################}
 {% if dellos_vrrp is defined and dellos_vrrp %}
-{% for key,value in dellos_vrrp.iteritems() %}
+{% for key,value in dellos_vrrp.items() %}
 {% if key == "vrrp" %}
     {% if value.delay_reload is defined %}
       {% if value.delay_reload >=0 %}

--- a/templates/dellos9_vrrp.j2
+++ b/templates/dellos9_vrrp.j2
@@ -54,7 +54,7 @@ dellos_vrrp:
             state: present
 #########################################}
 {% if dellos_vrrp is defined and dellos_vrrp %}
-{% for key,value in dellos_vrrp.iteritems() %} 
+{% for key,value in dellos_vrrp.items() %} 
 interface {{ key }}
   {% if value %}
   {% if value.vrrp is defined and value.vrrp %}


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs